### PR TITLE
Foi mudado a maneira de lidar com o ruído da imagem no 'trabalho4.py':

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/pacote2-py.iml
+++ b/.idea/pacote2-py.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.7" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/trabalho4.py
+++ b/trabalho4.py
@@ -3,6 +3,12 @@ import cv2
 import numpy as np
 from matplotlib import pyplot as plt
 
+#'60.bmp'
+#'82.bmp'
+#'114.bmp'
+#'150.bmp'
+#'205.bmp'
+
 INPUT_IMAGE = '150.bmp'
 IS_CINZA = True # se True abre a imagem como GrayScale, se não abre como Colorida
 
@@ -17,24 +23,23 @@ def exec():
         sys.exit()
     titles = ['image','mask','dilation','erosion','opening','closing','mg','th','img_tentativa']
 
-    mask = cv2.adaptiveThreshold(img,255,cv2.ADAPTIVE_THRESH_MEAN_C,cv2.THRESH_BINARY,11,2)
-    kernal = np.ones((2,2),np.uint8)
-    dilation =  cv2.dilate(mask,kernal,iterations=2)
-    erosion = cv2.erode(mask,kernal,iterations=1)
-    opening = cv2.morphologyEx(mask,cv2.MORPH_OPEN,kernal)
-    closing = cv2.morphologyEx(mask,cv2.MORPH_CLOSE,kernal,iterations=4)
-    mg = cv2.morphologyEx(mask,cv2.MORPH_GRADIENT,kernal)
-    th = cv2.morphologyEx(mask,cv2.MORPH_TOPHAT,kernal)
-    img_tentativa = cv2.morphologyEx(mg,cv2.MORPH_CLOSE,kernal,iterations=4)
+    mask = cv2.medianBlur(img, 7) #borrando a imagem para lidar um pouco com o ruído inicial, usando blur da mediana por ser mais efetivo contra ruídos
+    mask = cv2.adaptiveThreshold(mask,255,cv2.ADAPTIVE_THRESH_GAUSSIAN_C,cv2.THRESH_BINARY,7,2) #limiarizando a imagem com o gaussian blur (melhor para ruídos)
+    cv2.floodFill(mask, None, (0,0), 0) #preencho o background de preto (já que nenhuma imagem tem um grão de arroz encostado na borda é só setar o flood fill no pixel 0,0
+    kernal = np.ones((3,3),np.uint8) #kernel para morfologia
+    opening = cv2.morphologyEx(mask,cv2.MORPH_OPEN,kernal) #basta um opening (que nada mais é do que erodir -> dilatar em sequência, isso lida com os ruídos brancos
+    cv2.imshow('binarizada-arroz', opening)
+    cv2.imwrite('binarizada-arroz.bmp', mask)
 
-    images = [img,mask,dilation,erosion,opening,closing,mg,th,img_tentativa]
+
+    #images = [img,mask,opening,closing,mg,th,img_tentativa]
     # img_binarizada =cv2.adaptiveThreshold(img,255,cv2.ADAPTIVE_THRESH_MEAN_C,cv2.THRESH_BINARY,11,2)
     # cv2.imshow('img_binarizada',img_binarizada)
     for i in range(9):
-        plt.subplot(5, 2, i + 1), plt.imshow(images[i], 'gray')
+        #plt.subplot(5, 2, i + 1), plt.imshow(images[i], 'gray')
         plt.title(titles[i])
         plt.xticks([]), plt.yticks([])
 
-    plt.show()
+    #plt.show()
     cv2.waitKey() & 0xff
     cv2.destroyAllWindows()


### PR DESCRIPTION
Adicionado median blur para lidar com ruído inicial

Limiarização baseada no filtro média foi passada para filtro gaussiano (também com a intenção de lidar com ruído)

Remoção das múltiplas ocorrências de "dilatação" e "erosão" pois apenas 1 iteração de cada é necessária (a função MORPH_OPEN faz isso)